### PR TITLE
Add ICLR 2025: Parallel Quasi-Quantum Annealing with Gradient-Based Sampling (MIS section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,6 +771,10 @@ We mark work contributed by [Thinklab](http://thinklab.sjtu.edu.cn) with ⭐.
 
     *Shengyu Feng, Weiwei Sun, Shanda Li, Ameet Talwalkar, Yiming Yang*
 
+35. **Optimization by Parallel Quasi-Quantum Annealing with Gradient-Based Sampling** ICLR, 2025. [paper](https://openreview.net/forum?id=9EfBeXaXf0), [code](https://github.com/Yuma-Ichikawa/QQA4CO)
+
+	*Yuma Ichikawa, Yamato Arai*
+
 ### [Portfolio Optimization](#content)
 
 1. **⭐LinSATNet: The Positive Linear Satisfiability Neural Networks** ICML, 2023. [paper](https://icml.cc/virtual/2023/poster/25110), [code](https://github.com/Thinklab-SJTU/LinSATNet)


### PR DESCRIPTION
This PR adds the ICLR 2025 paper *"Optimization by Parallel Quasi-Quantum Annealing with Gradient-Based Sampling"* (Ichikawa & Arai) to `### Maximum Independent Set` as entry #35.

The paper benchmarks PQQA on MIS, MaxCut, and several Ising-style instances, and reports a competitive speed–quality trade-off vs iSCO, learning-based solvers, commercial solvers and specialised algorithms — particularly on large-scale graphs.

- OpenReview: https://openreview.net/forum?id=9EfBeXaXf0
- arXiv: https://arxiv.org/abs/2409.02135
- Code: https://github.com/Yuma-Ichikawa/QQA4CO (BSD-3-Clause-Clear, `pip install qqa`, Software DOI [10.5281/zenodo.19648231](https://doi.org/10.5281/zenodo.19648231))

Format follows existing entries: bold title → comma-separated venue/year → `[paper]` and `[code]` on one line → italic author list on the next line, indented with a tab.