### PR TITLE
Add PQQA (ICLR 2025) and CPRA (TMLR 2025) by Ichikawa et al.

### DIFF
--- a/README.md
+++ b/README.md
@@ -871,6 +871,10 @@ We mark work contributed by [Thinklab](http://thinklab.sjtu.edu.cn) with ⭐.
 
     *Utku Umur Acikalin, Aaron M. Ferber, Carla P. Gomes*
 
+22. **Optimization by Parallel Quasi-Quantum Annealing with Gradient-Based Sampling** ICLR, 2025. [paper](https://openreview.net/forum?id=9EfBeXaXf0), [code](https://github.com/Yuma-Ichikawa/QQA4CO)
+
+    *Yuma Ichikawa, Yamato Arai*
+
 ### [Vehicle Routing Problem](#content)
 
 1. **Learning to Perform Local Rewriting for Combinatorial Optimization.** NeurIPS, 2019. [paper](https://arxiv.org/abs/1810.00337), [code](https://github.com/facebookresearch/neural-rewriter)
@@ -1254,6 +1258,14 @@ We mark work contributed by [Thinklab](http://thinklab.sjtu.edu.cn) with ⭐.
 34. **FrontierCO: Real-World and Large-Scale Evaluation of Machine Learning Solvers for Combinatorial Optimization** ICLR, 2026. [paper](https://openreview.net/forum?id=BVprkacwFY), [code](https://github.com/sunnweiwei/FrontierCO)
 
     *Shengyu Feng, Weiwei Sun, Shanda Li, Ameet Talwalkar, Yiming Yang*
+
+35. **Optimization by Parallel Quasi-Quantum Annealing with Gradient-Based Sampling** ICLR, 2025. [paper](https://openreview.net/forum?id=9EfBeXaXf0), [code](https://github.com/Yuma-Ichikawa/QQA4CO)
+
+    *Yuma Ichikawa, Yamato Arai*
+
+36. **Continuous Parallel Relaxation for Finding Diverse Solutions in Combinatorial Optimization Problems** TMLR, 2025. [paper](https://openreview.net/forum?id=ix33zd5zCw), [code](https://github.com/Yuma-Ichikawa/QQA4CO)
+
+    *Yuma Ichikawa, Hiroaki Iwashita*
 
 ### [Generalization](#content)
 
@@ -1688,6 +1700,10 @@ We mark work contributed by [Thinklab](http://thinklab.sjtu.edu.cn) with ⭐.
 4. **Learning to Generate Columns with Application to Vertex Coloring** ICLR, 2023. [paper](https://openreview.net/forum?id=JHW30A4DXtO), [code](https://github.com/yuansuny/mlcg)
 
     *Yuan Sun, Andreas T Ernst, Xiaodong Li, Jake Weiner*
+
+5. **Optimization by Parallel Quasi-Quantum Annealing with Gradient-Based Sampling** ICLR, 2025. [paper](https://openreview.net/forum?id=9EfBeXaXf0), [code](https://github.com/Yuma-Ichikawa/QQA4CO)
+
+    *Yuma Ichikawa, Yamato Arai*
 
 ### [Maximal Common Subgraph](#content)
 


### PR DESCRIPTION
Hi maintainers — thanks for the great list!

This PR adds two recently-published unsupervised CO solvers from the same
research line as the already-listed CTRA paper (MaxCut #14, "Controlling
Continuous Relaxation for Combinatorial Optimization", NeurIPS 2024):

1. **Optimization by Parallel Quasi-Quantum Annealing with Gradient-Based
   Sampling** — Yuma Ichikawa, Yamato Arai. ICLR 2025.
   - Paper: https://openreview.net/forum?id=9EfBeXaXf0
   - Added to: Maximal Cut, Maximum Independent Set, Graph Coloring.

2. **Continuous Parallel Relaxation for Finding Diverse Solutions in
   Combinatorial Optimization Problems** — Yuma Ichikawa, Hiroaki
   Iwashita. TMLR 2025.
   - Paper: https://openreview.net/forum?id=ix33zd5zCw
   - Added to: Maximum Independent Set (penalty-/variation-diversified
     solutions for MIS-style problems).

Both papers share one open-source PyTorch implementation:
**Yuma-Ichikawa/QQA4CO** (PyPI `qqa`, DOI 10.5281/zenodo.19648231),
which exposes the three solvers under a unified API:

| Solver | Paper | API |
| --- | --- | --- |
| PQQA       | ICLR 2025    | `qqa.anneal` |
| CPRA       | TMLR 2025    | `qqa.pignn.train_cpra_pi_gnn` |
| CRA-PI-GNN | NeurIPS 2024 | `qqa.pignn.train_cra_pi_gnn` |

Each entry is added at the end of its section, so existing numbering is
unchanged. Happy to rebase or split into per-section commits if you
prefer.